### PR TITLE
Fix Channels not loading.

### DIFF
--- a/STALKER PLAYER.py
+++ b/STALKER PLAYER.py
@@ -360,7 +360,7 @@ class RequestThread(QThread):
             )
             response.raise_for_status()
             response_json = response.json()
-            total_items = response_json.get("js", {}).get("total_items", 0)
+            total_items = int(response_json.get("js", {}).get("total_items", 0))
             items_per_page = len(response_json.get("js", {}).get("data", []))
             total_pages = (total_items + items_per_page - 1) // items_per_page
 


### PR DESCRIPTION
Apparently, channels weren't loading before due to error : 

```
ERROR:root:Request thread error: can only concatenate str (not "int") to str
Traceback (most recent call last):
  File "C:\Users\rudra\PycharmProjects\PythonProject\main.py", line 156, in run
    channels = self.get_channels(
               ^^^^^^^^^^^^^^^^^^
  File "C:\Users\rudra\PycharmProjects\PythonProject\main.py", line 365, in get_channels
    total_pages = (total_items + items_per_page - 1) // items_per_page
                   ~~~~~~~~~~~~^~~~~~~~~~~~~~~~
TypeError: can only concatenate str (not "int") to str
```