### PR TITLE
feat: Add video player view with VLC integration and back navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.vscode
 # C extensions
 *.so
 


### PR DESCRIPTION
- Replaced setCentralWidget-based swapping with QStackedWidget for safe view management
- Implemented `launch_video_view(video_url)` to display a video player with a Back button
- Ensured VLC media player attaches to PyQt video frame (QFrame) correctly
- Added `return_to_main_view()` method to stop playback and return to main UI
- Prevented QWidget deletion errors by maintaining persistent references via QStackedWidget